### PR TITLE
Stub getPrincipal method

### DIFF
--- a/src/test/java/ch4mpy/WithMockAuthentication.java
+++ b/src/test/java/ch4mpy/WithMockAuthentication.java
@@ -66,6 +66,7 @@ public @interface WithMockAuthentication {
 @SuppressWarnings({"unchecked", "rawtypes"})
 public Authentication bogousAuthentication(WithMockAuthentication annotation) {
 	var auth = mock(Authentication.class);
+	when(auth.getPrincipal()).thenReturn("bogus");
 	when(auth.getName()).thenReturn(annotation.name());
 	when(auth.getAuthorities()).thenReturn((Collection) Stream.of(annotation.authorities()).map(SimpleGrantedAuthority::new).collect(Collectors.toSet()));
 	when(auth.isAuthenticated()).thenReturn(true);


### PR DESCRIPTION
This is necessary because if the principal is null, then getRemoteUser()
will return null. See
https://github.com/spring-projects/spring-security/blob/71b4248fe63595548ca7ca663b5fe376daebf4c8/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestWrapper.java#L123

Additional details can be found at https://stackoverflow.com/questions/60940334/why-do-i-get-null-authentication-as-controller-method-parameter-in-webmvcte